### PR TITLE
Improve feedback card styling for clearer homepage feedback display

### DIFF
--- a/cclean-frontend/src/pages/Home.css
+++ b/cclean-frontend/src/pages/Home.css
@@ -1,0 +1,177 @@
+/* Home.css */
+
+/* Background gradient similar to your friend's services page */
+.home-container {
+    min-height: 100vh;
+    background: linear-gradient(135deg, #e6f7ff, #b3d9ff);
+    position: relative;
+    font-family: sans-serif;
+  }
+  
+  /* Header Section */
+  .home-header {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 4rem 2rem;
+    position: relative;
+  }
+  
+  .home-header-content {
+    max-width: 600px;
+    z-index: 10;
+  }
+  
+  .home-title {
+    font-size: 3rem;
+    font-weight: bold;
+    color: #333;
+  }
+  
+  .home-description {
+    margin-top: 1.5rem;
+    font-size: 1.125rem;
+    line-height: 1.5;
+    color: #555;
+  }
+  
+  .home-learn-more-button {
+    margin-top: 1.5rem;
+    padding: 0.75rem 1.5rem;
+    background-color: #007bff;
+    color: #fff;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+  }
+  
+  .home-learn-more-button:hover {
+    background-color: #0056b3;
+  }
+  
+  /* Image container */
+  .home-image-container {
+    position: absolute;
+    top: 4rem;
+    right: 2rem;
+    width: 50%;
+    max-width: 500px;
+    display: flex;
+    justify-content: flex-end;
+  }
+  
+  .home-image-container img {
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    transition: transform 0.5s ease;
+  }
+  
+  .home-image-container img:hover {
+    transform: scale(1.05);
+  }
+  
+  /* Feedback Section */
+  .feedback-section {
+    padding: 2rem;
+  }
+  
+  .feedback-section-title {
+    font-size: 2rem;
+    font-weight: bold;
+    margin-bottom: 2rem;
+    text-align: center;
+    color: #333;
+  }
+  
+  .loading-text,
+  .error-text {
+    text-align: center;
+    color: #333;
+  }
+  
+  .error-text {
+    color: red;
+  }
+  
+  /* Feedback grid */
+  .feedback-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+  }
+  
+  /* Feedback card */
+  .feedback-card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    padding: 1rem;
+    transition: box-shadow 0.2s ease;
+  }
+  
+  .feedback-card:hover {
+    box-shadow: 0 6px 10px rgba(0,0,0,0.15);
+  }
+  
+  .feedback-content {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: #333;
+  }
+  
+  .feedback-rating,
+  .feedback-user,
+  .feedback-status {
+    font-size: 0.875rem;
+    color: #666;
+    margin-bottom: 0.5rem;
+  }
+  
+  .feedback-status.visible {
+    color: #2d7a2e; /* green for visible */
+  }
+  
+  .feedback-status.invisible {
+    color: #b21f1f; /* red for invisible */
+  }
+
+  @media (max-width: 768px) {
+    .home-image-container {
+      position: static;
+      width: 100%;
+      margin-top: 2rem;
+      display: flex;
+      justify-content: center;
+    }
+  }
+  .star-rating-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+  
+  .star-container {
+    display: flex;
+    align-items: center;
+  }
+  
+  .star {
+    font-size: 1.25rem;
+    color: #ccc;
+    margin-right: 4px;
+  }
+  
+  .star.filled {
+    color: #f4c430; /* Gold color for filled stars */
+  }
+  
+  .rating-text {
+    margin-left: 8px;
+    font-size: 0.875rem;
+    color: #666;
+  }
+  

--- a/cclean-frontend/src/pages/Home.tsx
+++ b/cclean-frontend/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../api/axios';
+import './Home.css';
 
 interface Feedback {
   feedback_id: string;
@@ -36,60 +37,71 @@ const Home = () => {
     fetchFeedbacks();
   }, []);
 
+  const renderStars = (rating: number) => {
+    const stars = [];
+    for (let i = 1; i <= 5; i++) {
+      stars.push(
+        <span key={i} className={`star ${i <= rating ? 'filled' : ''}`}>
+          ★
+        </span>
+      );
+    }
+    return <div className="star-container">{stars}</div>;
+  };
+
   return (
-    <div className="bg-gradient-to-b from-[#E4EDF5] to-[#F7F8FC] min-h-screen relative">
-      <header className="flex flex-col lg:flex-row justify-between items-center py-20 px-10 lg:px-0">
-        <div className="max-w-lg z-10 lg:pl-10">
-          <h1 className="text-5xl font-bold text-gray-900">C CLEAN inc.</h1>
-          <p className="mt-6 text-lg text-gray-600">
+    <div className="home-container">
+      <header className="home-header">
+        <div className="home-header-content">
+          <h1 className="home-title">C CLEAN inc.</h1>
+          <p className="home-description">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad.
           </p>
           <button
             onClick={() => navigate('/about-us')}
-            className="mt-6 px-6 py-3 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
+            className="home-learn-more-button"
           >
             Learn More
           </button>
         </div>
-        <div className="absolute inset-y-0 right-0 w-full lg:w-1/2 flex justify-end">
+
+        <div className="home-image-container">
           <img
             src="/images/cleaning-product.png"
             alt="Cleaning Product"
-            className="h-full object-contain lg:object-cover"
           />
         </div>
       </header>
 
-      {/* Feedback Section */}
-      <section className="p-10">
-        <h2 className="text-3xl font-bold mb-6">Customer Feedbacks</h2>
+      <section className="feedback-section">
+        <h2 className="feedback-section-title">Customer Feedbacks</h2>
         {loading ? (
-          <p>Loading feedbacks...</p>
+          <p className="loading-text">Loading feedbacks...</p>
         ) : error ? (
-          <p className="text-red-500">{error}</p>
+          <p className="error-text">{error}</p>
         ) : feedbacks.length > 0 ? (
-          <ul className="space-y-4">
+          <div className="feedback-grid">
             {feedbacks.map((feedback) => (
-              <li
-                key={feedback.feedback_id}
-                className="p-4 border rounded-lg shadow-sm"
-              >
-                <p className="text-lg font-semibold">{feedback.content}</p>
-                <p className="text-sm text-gray-500">Rating: {feedback.stars}/5</p>
-                <p className="text-sm text-gray-500">User ID: {feedback.user_id}</p>
+              <div key={feedback.feedback_id} className="feedback-card">
+                <p className="feedback-content">"{feedback.content}"</p>
+                <div className="star-rating-container">
+                  {renderStars(feedback.stars)}
+                  <span className="rating-text">{feedback.stars}/5</span>
+                </div>
+                <p className="feedback-user">User ID: {feedback.user_id}</p>
                 <p
-                  className={`text-sm mt-2 ${
-                    feedback.status === 'VISIBLE' ? 'text-green-600' : 'text-red-600'
+                  className={`feedback-status ${
+                    feedback.status === 'VISIBLE' ? 'visible' : 'invisible'
                   }`}
                 >
                   Status: {feedback.status}
                 </p>
-              </li>
+              </div>
             ))}
-          </ul>
+          </div>
         ) : (
-          <p>No feedback available at the moment.</p>
+          <p className="loading-text">No feedback available at the moment.</p>
         )}
       </section>
     </div>


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CCICC-49


## Context:
Customers need a more visually clear way to view feedbacks on the homepage.
Current feedback display lacks proper styling and star rating representation, causing confusion.
Aligning with the project's standard styling practices to improve user experience.

## Changes
Added a grid layout to display feedbacks as individual cards.
Introduced a star rating component to visually represent feedback ratings.
Included numeric ratings (e.g., "4/5") alongside star ratings for clarity.
Refined card styling with improved spacing, background colors, and typography.
Ensured responsive design so feedback cards look good on various screen sizes.

Before changes:
![image](https://github.com/user-attachments/assets/065315f1-cdb5-4309-996e-4e162006c72a)

After Changes:
![image](https://github.com/user-attachments/assets/e8b68e2f-5641-45de-9989-f6aaa80d1795)


## Dev notes (Optional)
-During my full stack i will adjust the status'


