### PR TITLE
feat(CCICC-72): Refine Profile Page - Add user choice for customer pr…

### DIFF
--- a/cclean-frontend/src/pages/Profile.tsx
+++ b/cclean-frontend/src/pages/Profile.tsx
@@ -1,21 +1,217 @@
+import React, { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
+import axiosInstance from "../api/axios";
 import "./Profile.css";
-const Profile = () => {
+
+interface CustomerResponse {
+  customerId: string;
+  firstName: string | null;
+  lastName: string | null;
+  companyName: string | null;
+  email: string | null;
+  phoneNumber: string | null;
+  address: string | null;
+}
+
+const Profile: React.FC = () => {
   const { user, isAuthenticated, isLoading } = useAuth0();
+
+  // If null, we haven't prompted. If true, user wants a customer profile. If false, user doesn't.
+  const [wantsProfile, setWantsProfile] = useState<boolean | null>(null);
+
+  // The DB record if they do want a profile
+  const [customerData, setCustomerData] = useState<CustomerResponse | null>(null);
+
+  // Local form fields for editing
+  const [form, setForm] = useState({
+    firstName: "",
+    lastName: "",
+    phoneNumber: "",
+    companyName: "",
+    address: "",
+  });
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  // If user wants a profile, and we haven't loaded it yet, fetch from backend
+  useEffect(() => {
+    if (!isLoading && isAuthenticated && user?.email && wantsProfile === true && !customerData) {
+      axiosInstance
+        .get(`/customers/byEmail?email=${encodeURIComponent(user.email)}`)
+        .then((res) => {
+          const foundCustomer = res.data as CustomerResponse;
+          setCustomerData(foundCustomer);
+          setForm({
+            firstName: foundCustomer.firstName || "",
+            lastName: foundCustomer.lastName || "",
+            phoneNumber: foundCustomer.phoneNumber || "",
+            companyName: foundCustomer.companyName || "",
+            address: foundCustomer.address || "",
+          });
+        })
+        .catch((err) => {
+          console.error("Error fetching/creating customer:", err);
+        });
+    }
+  }, [isLoading, isAuthenticated, user?.email, wantsProfile, customerData]);
+
+  // Handler for all input fields
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // Save to backend
+  const handleSave = () => {
+    if (!customerData) return;
+
+    const updatedCustomer = {
+      ...customerData,
+      firstName: form.firstName || null,
+      lastName: form.lastName || null,
+      companyName: form.companyName || null,
+      phoneNumber: form.phoneNumber || null,
+      address: form.address || null,
+    };
+
+    axiosInstance
+      .put(`/customers/${customerData.customerId}`, updatedCustomer)
+      .then((res) => {
+        alert("Profile updated!");
+        setCustomerData(res.data);
+        setForm({
+          firstName: res.data.firstName || "",
+          lastName: res.data.lastName || "",
+          phoneNumber: res.data.phoneNumber || "",
+          companyName: res.data.companyName || "",
+          address: res.data.address || "",
+        });
+        setIsEditing(false);
+      })
+      .catch((err) => {
+        console.error("Error updating profile:", err);
+        alert("Error updating profile");
+      });
+  };
+
   if (isLoading) {
     return <div className="profile-loading">Loading ...</div>;
   }
-  return (
-    isAuthenticated &&
-    user && (
+
+  if (!isAuthenticated || !user) {
+    return <div>Please log in to see your profile.</div>;
+  }
+
+  // If user hasn't decided if they want a profile or not, show the prompt
+  if (wantsProfile === null) {
+    return (
       <div className="profile-container">
         <div className="profile-image-wrapper">
           <img className="profile-image" src={user.picture} alt={user.name} />
         </div>
         <h2 className="profile-name">{user.name}</h2>
         <p className="profile-email">{user.email}</p>
+        <p>Would you like to set up a Customer Profile?</p>
+        <button onClick={() => setWantsProfile(true)}>Yes</button>
+        <button onClick={() => setWantsProfile(false)}>No</button>
       </div>
-    )
+    );
+  }
+
+  // If user said "No," we show just their basic Auth0 data
+  if (wantsProfile === false) {
+    return (
+      <div className="profile-container">
+        <div className="profile-image-wrapper">
+          <img className="profile-image" src={user.picture} alt={user.name} />
+        </div>
+        <h2 className="profile-name">{user.name}</h2>
+        <p className="profile-email">{user.email}</p>
+        <p>You have opted out of creating a customer profile.</p>
+        <button onClick={() => setWantsProfile(true)}>Create Profile Anyway</button>
+      </div>
+    );
+  }
+
+  // If user said "Yes," but we haven't fetched or created a record yet, wait
+  if (wantsProfile === true && !customerData) {
+    return <div>Loading your customer profile...</div>;
+  }
+
+  // Otherwise, user said "Yes" and we have a record
+  return (
+    <div className="profile-container">
+      <div className="profile-image-wrapper">
+        <img className="profile-image" src={user.picture} alt={user.name} />
+      </div>
+      <h2 className="profile-name">{user.name}</h2>
+      <p className="profile-email">{user.email}</p>
+
+      {/* Show read‐only fields if not editing */}
+      {!isEditing && (
+        <>
+          <p><strong>Customer ID:</strong> {customerData?.customerId}</p>
+          <p><strong>First Name:</strong> {customerData?.firstName || ""}</p>
+          <p><strong>Last Name:</strong> {customerData?.lastName || ""}</p>
+          <p><strong>Phone:</strong> {customerData?.phoneNumber || ""}</p>
+          <p><strong>Company:</strong> {customerData?.companyName || ""}</p>
+          <p><strong>Address:</strong> {customerData?.address || ""}</p>
+          <button onClick={() => setIsEditing(true)}>Edit Profile</button>
+        </>
+      )}
+
+      {/* Show input fields if editing */}
+      {isEditing && (
+        <>
+          <div style={{ margin: "0.5rem 0" }}>
+            <label>First Name: </label>
+            <input
+              name="firstName"
+              value={form.firstName}
+              onChange={handleChange}
+            />
+          </div>
+          <div style={{ margin: "0.5rem 0" }}>
+            <label>Last Name: </label>
+            <input
+              name="lastName"
+              value={form.lastName}
+              onChange={handleChange}
+            />
+          </div>
+          <div style={{ margin: "0.5rem 0" }}>
+            <label>Phone: </label>
+            <input
+              name="phoneNumber"
+              value={form.phoneNumber}
+              onChange={handleChange}
+            />
+          </div>
+          <div style={{ margin: "0.5rem 0" }}>
+            <label>Company: </label>
+            <input
+              name="companyName"
+              value={form.companyName}
+              onChange={handleChange}
+            />
+          </div>
+          <div style={{ margin: "0.5rem 0" }}>
+            <label>Address: </label>
+            <input
+              name="address"
+              value={form.address}
+              onChange={handleChange}
+            />
+          </div>
+
+          <button onClick={handleSave} style={{ marginRight: "1rem" }}>
+            Save Profile
+          </button>
+          <button onClick={() => setIsEditing(false)}>Cancel</button>
+        </>
+      )}
+    </div>
   );
 };
+
 export default Profile;

--- a/init.sql
+++ b/init.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS customers (
     first_name VARCHAR(50) NOT NULL,
     last_name VARCHAR(50) NOT NULL,
     email VARCHAR(100) UNIQUE NOT NULL,
-    phone_number VARCHAR(20),
+    phone_number VARCHAR(20) NULL,
     password_hash VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_login TIMESTAMP

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerService.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerService.java
@@ -18,5 +18,8 @@ public interface CustomerService {
     CustomerResponseModel addCustomer(CustomerRequestModel customerRequestModel);
 
     CustomerResponseModel updateCustomer(String customerId, CustomerRequestModel customerRequestModel);
-    
+
+    CustomerResponseModel getOrCreateCustomerByEmail(String email);
+
+
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerServiceImpl.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerServiceImpl.java
@@ -84,8 +84,25 @@ public class CustomerServiceImpl implements CustomerService{
         existingCustomer.setCompanyName(customerRequestModel.getCompanyName());
         existingCustomer.setEmail(customerRequestModel.getEmail());
         existingCustomer.setPhoneNumber(customerRequestModel.getPhoneNumber());
+        existingCustomer.setAddress(customerRequestModel.getAddress());
 
         return customerResponseMapper.entityToResponseModel(customerRepository.save(existingCustomer));
+    }
+
+    @Override
+    public CustomerResponseModel getOrCreateCustomerByEmail(String email) {
+        Customer existing = customerRepository.findByEmail(email);
+        if (existing != null) {
+            return customerResponseMapper.entityToResponseModel(existing);
+        }
+
+        // If no record exists, create a new blank one
+        Customer newCustomer = new Customer();
+        newCustomer.setCustomerIdentifier(new CustomerIdentifier());
+        newCustomer.setEmail(email);
+        // Everything else stays null
+        Customer saved = customerRepository.save(newCustomer);
+        return customerResponseMapper.entityToResponseModel(saved);
     }
 
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/datalayer/Customer.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/datalayer/Customer.java
@@ -30,6 +30,9 @@ public class Customer {
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "phone_number", nullable = false)
+    @Column(name = "phone_number") // no nullable=false
     private String phoneNumber;
+
+    @Column(name = "address")
+    private String address;
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerController.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerController.java
@@ -87,4 +87,18 @@ public class CustomerController {
         }
         return ResponseEntity.ok(customers);
     }
+
+    @GetMapping("/byEmail")
+    public ResponseEntity<CustomerResponseModel> getCustomerByEmail(@RequestParam String email) {
+        try {
+            // Must use getOrCreateCustomerByEmail here
+            CustomerResponseModel customer = customerService.getOrCreateCustomerByEmail(email);
+            return ResponseEntity.ok(customer);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+
 }
+

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerRequestModel.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerRequestModel.java
@@ -14,5 +14,6 @@ public class CustomerRequestModel {
     private String companyName;
     private String email;
     private String phoneNumber;
+    private String address;
     
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerResponseModel.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/presentationlayer/CustomerResponseModel.java
@@ -15,4 +15,5 @@ public class CustomerResponseModel {
     private String companyName;   // optional if business
     private String email;
     private String phoneNumber;
+    private String address;
 }

--- a/src/main/java/com/ccleaninc/cclean/security/SecurityConfig.java
+++ b/src/main/java/com/ccleaninc/cclean/security/SecurityConfig.java
@@ -15,15 +15,22 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
-                .cors(Customizer.withDefaults())
-                .oauth2ResourceServer(oauth2 -> oauth2
-                        .jwt(jwt -> jwt.jwtAuthenticationConverter(makePermissionsConverter())))
-                .build();
-    }
+                // Disable CSRF for stateless APIs
+                .csrf(csrf -> csrf.disable())
 
-    private JwtAuthenticationConverter makePermissionsConverter() {
-        return CustomJwtAuthenticationConverter.jwtAuthenticationConverter();
+                // Let all requests pass freely (for dev/demo)
+                .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
+
+                // Allow CORS
+                .cors(Customizer.withDefaults())
+
+                // OAuth2 resource server with JWT
+                .oauth2ResourceServer(oauth2 ->
+                        oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(
+                                CustomJwtAuthenticationConverter.jwtAuthenticationConverter()
+                        ))
+                )
+                .build();
     }
 }
 

--- a/src/main/resources/h2_schema.sql
+++ b/src/main/resources/h2_schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS customers (
     last_name VARCHAR(50),                        -- Optional last name
     company_name VARCHAR(100),                    -- Optional company name
     email VARCHAR(100) NOT NULL UNIQUE,           -- Required email
-    phone_number VARCHAR(20) NOT NULL
+    phone_number VARCHAR(20) NULL,
+    address VARCHAR(255) DEFAULT NULL
 );
 
 -- Create an index for customer_id

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS customers (
     last_name VARCHAR(50),                       -- Optional last name
     company_name VARCHAR(100),                   -- Optional company name
     email VARCHAR(100) UNIQUE NOT NULL,          -- Common email field
-    phone_number VARCHAR(20) NOT NULL                    -- Common phone number field
+    phone_number VARCHAR(20) NULL,                    -- Common phone number field
+    address VARCHAR(255) DEFAULT NULL
 );
 
 -- Added an index to customer_id for foreign key references

--- a/src/test/java/com/ccleaninc/cclean/customersubdomain/businesslayer/CustomerServiceUnitTest.java
+++ b/src/test/java/com/ccleaninc/cclean/customersubdomain/businesslayer/CustomerServiceUnitTest.java
@@ -218,4 +218,29 @@ public class CustomerServiceUnitTest {
         assertThrows(NotFoundException.class, () -> customerService.deleteCustomerByCustomerId(customerId));
     }
 
+    @Test
+    void getOrCreateCustomerByEmail_ShouldReturnExistingCustomer() {
+        String email = "existing@mail.com";
+        when(customerRepository.findByEmail(email)).thenReturn(customer);
+        when(customerResponseMapper.entityToResponseModel(customer)).thenReturn(customerResponseModel);
+
+        CustomerResponseModel response = customerService.getOrCreateCustomerByEmail(email);
+
+        assertNotNull(response);
+        assertEquals(customerResponseModel.getEmail(), response.getEmail());
+    }
+
+    @Test
+    void getOrCreateCustomerByEmail_ShouldCreateAndReturnNewCustomer() {
+        String email = "new@mail.com";
+        when(customerRepository.findByEmail(email)).thenReturn(null);
+        when(customerRepository.save(any(Customer.class))).thenReturn(customer);
+        when(customerResponseMapper.entityToResponseModel(customer)).thenReturn(customerResponseModel);
+
+        CustomerResponseModel response = customerService.getOrCreateCustomerByEmail(email);
+
+        assertNotNull(response);
+        assertEquals(customerResponseModel.getEmail(), response.getEmail());
+    }
+
 }

--- a/src/test/java/com/ccleaninc/cclean/customersubdomain/presentationlayer/CustomerControllerUnitTest.java
+++ b/src/test/java/com/ccleaninc/cclean/customersubdomain/presentationlayer/CustomerControllerUnitTest.java
@@ -212,5 +212,27 @@ public class CustomerControllerUnitTest {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
+    @Test
+    void getCustomerByEmail_ShouldReturnCustomer() {
+        String email = "john.doe@mail.com";
+        when(customerService.getOrCreateCustomerByEmail(email)).thenReturn(customerResponseModel);
+
+        ResponseEntity<CustomerResponseModel> response = customerController.getCustomerByEmail(email);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(customerResponseModel, response.getBody());
+    }
+
+    @Test
+    void getCustomerByEmail_CustomerNotFound_ShouldReturnInternalServerError() {
+        String email = "nonexistent@mail.com";
+        when(customerService.getOrCreateCustomerByEmail(email)).thenThrow(new RuntimeException("Customer not found"));
+
+        ResponseEntity<CustomerResponseModel> response = customerController.getCustomerByEmail(email);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
 
 }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CCICC-72

## Context:
This PR refines the Profile Page by introducing a **user choice prompt** for creating a customer profile. Now, when any user logs in, they will be asked if they want to create a customer profile. If they decline, only their email will be shown. If they agree, the system will fetch or create their profile as before.

## Changes:

- **New Prompt System**:
  - When a user logs in for the first time, they are **prompted** to set up a customer profile.
  - If the user selects **"Yes"**, a customer profile is created or fetched.
  - If the user selects **"No"**, only their email and name are displayed.

- **Profile Page Enhancements**:
  - Displays **Customer ID** if a profile exists.
  - Allows users to **change their mind later** and create a profile if they initially opted out.
  - Keeps **edit functionality** for users with a profile.

- **Backend Adjustments**:
  - The `/customers/byEmail` API **is only called** if the user chooses to set up a profile.
  - Prevents unnecessary auto-creation of profiles for all users.

## Before and After UI (Required for UI-impacting PRs)

After Changes:
![image](https://github.com/user-attachments/assets/876b4ffd-3033-437e-a707-30380b8dce5d)
![image](https://github.com/user-attachments/assets/40e8bcb0-b03f-4cd1-bdfc-21fbeadc7f20)
![image](https://github.com/user-attachments/assets/5681006c-6a68-40a2-a078-ea9c0075f366)


## Dev Notes:
- This feature ensures **no hard-coded restrictions** on certain emails.
- Admins/employees won't have profiles unless they **opt-in**.
- No breaking changes; existing customer profiles will function as expected.
- I plan to flesh out the profiles for admin and employees later, as well as potentially changing the profile picture.

**Front-end updates related to UI improvements will continue in upcoming sprints.**
