### PR TITLE
feat(CCLEAN-CCICC-97): eliminate use of IDs in frontend PART 1

### DIFF
--- a/cclean-frontend/src/pages/MyAppointments.css
+++ b/cclean-frontend/src/pages/MyAppointments.css
@@ -1,149 +1,125 @@
-/* MyAppointments.css */
-
-/* Container */
+/* General Styling */
 .my-appointments-container {
-    padding: 2rem;
-    background: linear-gradient(135deg, #b3d9ff, #e6f7ff);
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    font-family: Arial, sans-serif;
+  padding: 2rem;
+  background: linear-gradient(135deg, #b3d9ff, #e6f7ff);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: Arial, sans-serif;
+}
+
+/* Title */
+.my-appointments-title {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 1.5rem;
+  color: #2c3e50;
+  text-align: center;
+}
+
+/* Appointments Card */
+.my-appointments-card {
+  width: 90%;
+  max-width: 600px;
+  background: #ffffff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+/* User Email */
+.my-appointments-email {
+  font-size: 1rem;
+  color: #34495e;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+/* Appointment Item */
+.appointment-item {
+  background: #f9f9f9;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+  text-align: left;
+  transition: transform 0.2s ease-in-out;
+}
+
+.appointment-item:hover {
+  transform: scale(1.02);
+}
+
+/* Appointment Details */
+.appointment-item p {
+  margin: 0.5rem 0;
+  font-size: 1rem;
+  color: #2c3e50;
+}
+
+.appointment-status {
+  font-weight: bold;
+}
+
+.status-pending {
+  color: #e67e22;
+}
+
+.status-confirmed {
+  color: #27ae60;
+}
+
+.status-cancelled {
+  color: #c0392b;
+}
+
+/* No Appointments Message */
+.no-appointments {
+  font-size: 1.2rem;
+  color: #7f8c8d;
+}
+
+/* Loader */
+.loader {
+  width: 40px;
+  height: 40px;
+  border: 5px solid #ddd;
+  border-top-color: #007bff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 20px auto;
+}
+
+@keyframes spin {
+  100% {
+      transform: rotate(360deg);
   }
-  
-  /* Title */
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .my-appointments-card {
+      width: 95%;
+      padding: 1.2rem;
+  }
+
   .my-appointments-title {
-    font-size: 2.5rem;
-    font-weight: bold;
-    margin-bottom: 2rem;
-    color: #2c3e50;
-    text-align: center;
+      font-size: 1.8rem;
   }
-  
-  /* Form */
-  .my-appointments-form {
-    margin-bottom: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+}
+
+@media (max-width: 480px) {
+  .my-appointments-title {
+      font-size: 1.5rem;
   }
-  
-  .my-appointments-form label {
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
-    color: #34495e;
+
+  .my-appointments-card {
+      padding: 1rem;
   }
-  
-  .my-appointments-form input {
-    padding: 0.5rem;
-    margin-bottom: 1rem;
-    border: 1px solid #007bff;
-    border-radius: 5px;
-    width: 300px;
-    font-size: 1rem;
+
+  .appointment-item p {
+      font-size: 0.9rem;
   }
-  
-  .my-appointments-form button {
-    padding: 0.5rem 1rem;
-    background-color: #007bff;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: background-color 0.3s ease;
-  }
-  
-  .my-appointments-form button:hover {
-    background-color: #0056b3;
-  }
-  
-  /* Error Message */
-  .my-appointments-error {
-    color: #e74c3c;
-    font-size: 1rem;
-    font-weight: bold;
-    margin-top: 1rem;
-  }
-  
-  /* No Results Message */
-  .my-appointments-no-results {
-    color: #34495e;
-    font-size: 1.2rem;
-    margin-top: 1rem;
-  }
-  
-  /* Table */
-  .my-appointments-table {
-    width: 100%;
-    max-width: 800px;
-    border-collapse: collapse;
-    margin: 0 auto;
-    background-color: white;
-    border-radius: 10px;
-    overflow: hidden;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  }
-  
-  .my-appointments-table th {
-    background-color: #007bff;
-    color: white;
-    text-transform: uppercase;
-    font-weight: bold;
-    padding: 1rem;
-    text-align: left;
-  }
-  
-  .my-appointments-table td {
-    padding: 1rem;
-    color: #34495e;
-    border-bottom: 1px solid #ddd;
-    text-align: left;
-  }
-  
-  .my-appointments-table tr:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-  
-  .my-appointments-table tr:nth-child(odd) {
-    background-color: white;
-  }
-  
-  .my-appointments-table tr:hover {
-    background-color: #e3f2fd;
-    transition: background-color 0.3s ease;
-  }
-  
-  /* Buttons in Table */
-  .my-appointments-table button {
-    margin-right: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-  }
-  
-  .my-appointments-table button:hover {
-    opacity: 0.9;
-  }
-  
-  .my-appointments-table button:first-child {
-    background-color: #e74c3c;
-    color: white;
-  }
-  
-  .my-appointments-table button:first-child:hover {
-    background-color: #c0392b;
-  }
-  
-  .my-appointments-table button:last-child {
-    background-color: #f39c12;
-    color: white;
-  }
-  
-  .my-appointments-table button:last-child:hover {
-    background-color: #d35400;
-  }
-  
+}

--- a/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentService.java
+++ b/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentService.java
@@ -32,4 +32,6 @@ public interface AppointmentService {
     AppointmentResponseModel addAppointmentToCustomerAccount(String customerId, AppointmentRequestModel appointmentRequestModel) throws MessagingException;
 
     Page<AppointmentResponseModel> getAllAppointmentsPagination (Pageable pageable);
+
+    List<AppointmentResponseModel> getAppointmentsByCustomerEmail(String email);
 }

--- a/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentServiceImpl.java
+++ b/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentServiceImpl.java
@@ -8,8 +8,10 @@ import com.ccleaninc.cclean.appointmentssubdomain.datamapperlayer.AppointmentReq
 import com.ccleaninc.cclean.appointmentssubdomain.datamapperlayer.AppointmentResponseMapper;
 import com.ccleaninc.cclean.appointmentssubdomain.presentationlayer.AppointmentRequestModel;
 import com.ccleaninc.cclean.appointmentssubdomain.presentationlayer.AppointmentResponseModel;
+import com.ccleaninc.cclean.customerssubdomain.businesslayer.CustomerService;
 import com.ccleaninc.cclean.customerssubdomain.datalayer.Customer;
 import com.ccleaninc.cclean.customerssubdomain.datalayer.CustomerRepository;
+import com.ccleaninc.cclean.customerssubdomain.presentationlayer.CustomerResponseModel;
 import com.ccleaninc.cclean.emailsubdomain.businesslayer.EmailService;
 import com.ccleaninc.cclean.utils.exceptions.InvalidInputException;
 import com.ccleaninc.cclean.utils.exceptions.NotFoundException;
@@ -39,15 +41,14 @@ public class AppointmentServiceImpl implements AppointmentService {
     private final CustomerRepository customerRepository;
     private final AppointmentResponseMapper appointmentResponseMapper;
     private final AppointmentRequestMapper appointmentRequestMapper;
+    private final CustomerService customerService;
 
     private EmailService emailService;
-
 
     @Override
     public List<AppointmentResponseModel> getAllAppointments() {
         return appointmentResponseMapper.entityToResponseModelList(appointmentRepository.findAll());
     }
-
 
     @Override
     public AppointmentResponseModel createAppointment(AppointmentRequestModel requestModel) {
@@ -66,11 +67,11 @@ public class AppointmentServiceImpl implements AppointmentService {
 
         Appointment newAppointment = Appointment.builder()
                 .appointmentIdentifier(new AppointmentIdentifier()) // auto-generated UUID
-                .customerId(foundCustomer.getCustomerIdentifier().getCustomerId())  // store the actual ID
+                .customerId(foundCustomer.getCustomerIdentifier().getCustomerId()) // store the actual ID
                 .customerFirstName(foundCustomer.getFirstName())
                 .customerLastName(foundCustomer.getLastName())
                 .appointmentDate(requestModel.getAppointmentDate())
-                .services(requestModel.getServices())   // e.g. "id1,id2"
+                .services(requestModel.getServices()) // e.g. "id1,id2"
                 .comments(requestModel.getComments())
                 .status(requestModel.getStatus() == null ? Status.pending : requestModel.getStatus())
                 .build();
@@ -79,19 +80,18 @@ public class AppointmentServiceImpl implements AppointmentService {
         return appointmentResponseMapper.entityToResponseModel(savedAppointment);
     }
 
-
     @Override
     public AppointmentResponseModel getAppointmentByAppointmentId(String appointmentId) {
         if (appointmentId == null || appointmentId.length() != 36) {
             throw new InvalidInputException("Appointment ID must be a valid 36-character string: " + appointmentId);
         }
-        Appointment appointment = appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
+        Appointment appointment = appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
         if (appointment == null) {
             throw new NotFoundException("Appointment with ID " + appointmentId + " was not found.");
         }
         return appointmentResponseMapper.entityToResponseModel(appointment);
     }
-
 
     @Override
     public AppointmentResponseModel addAppointment(AppointmentRequestModel appointmentRequestModel) {
@@ -105,7 +105,6 @@ public class AppointmentServiceImpl implements AppointmentService {
         appointment.setCustomerFirstName(appointmentRequestModel.getCustomerFirstName());
         appointment.setCustomerLastName(appointmentRequestModel.getCustomerLastName());
 
-
         appointment.setCustomerId(UUID.randomUUID().toString());
 
         appointment.setAppointmentDate(appointmentRequestModel.getAppointmentDate());
@@ -117,9 +116,9 @@ public class AppointmentServiceImpl implements AppointmentService {
         return appointmentResponseMapper.entityToResponseModel(savedAppointment);
     }
 
-
     @Override
-    public AppointmentResponseModel updateAppointment(String appointmentId, AppointmentRequestModel appointmentRequestModel) {
+    public AppointmentResponseModel updateAppointment(String appointmentId,
+            AppointmentRequestModel appointmentRequestModel) {
         if (appointmentId == null || appointmentId.length() != 36) {
             throw new InvalidInputException("Appointment ID must be a valid 36-character string: " + appointmentId);
         }
@@ -127,8 +126,8 @@ public class AppointmentServiceImpl implements AppointmentService {
             throw new InvalidInputException("Appointment request model cannot be null.");
         }
 
-        Appointment appointment = appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
-
+        Appointment appointment = appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
 
         appointment.setCustomerFirstName(appointmentRequestModel.getCustomerFirstName());
         appointment.setCustomerLastName(appointmentRequestModel.getCustomerLastName());
@@ -144,13 +143,13 @@ public class AppointmentServiceImpl implements AppointmentService {
         return appointmentResponseMapper.entityToResponseModel(savedAppointment);
     }
 
-
     @Override
     public void deleteAppointmentByAppointmentId(String appointmentId) {
         if (appointmentId == null || appointmentId.length() != 36) {
             throw new InvalidInputException("Appointment ID must be a valid 36-character string: " + appointmentId);
         }
-        Appointment existing = appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
+        Appointment existing = appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
         if (existing == null) {
             throw new NotFoundException("Appointment with ID " + appointmentId + " was not found.");
         }
@@ -175,12 +174,14 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     @Override
-    public AppointmentResponseModel updateAppointmentForCustomer(String appointmentId, AppointmentRequestModel requestModel) {
+    public AppointmentResponseModel updateAppointmentForCustomer(String appointmentId,
+            AppointmentRequestModel requestModel) {
         if (appointmentId == null || appointmentId.length() != 36) {
             throw new InvalidInputException("Appointment ID must be a valid 36-character string.");
         }
 
-        Appointment appointment = appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
+        Appointment appointment = appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId(appointmentId);
         if (appointment == null) {
             throw new NotFoundException("Appointment not found for " + appointmentId);
         }
@@ -276,7 +277,8 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     @Override
-    public AppointmentResponseModel addAppointmentToCustomerAccount(String customerId, AppointmentRequestModel appointmentRequestModel) throws MessagingException, MessagingException {
+    public AppointmentResponseModel addAppointmentToCustomerAccount(String customerId,
+            AppointmentRequestModel appointmentRequestModel) throws MessagingException, MessagingException {
         Customer customerAccount = customerRepository.findByCustomerIdentifier_CustomerId(customerId).orElse(null);
 
         if (customerAccount == null) {
@@ -286,8 +288,6 @@ public class AppointmentServiceImpl implements AppointmentService {
 
         // ✅ Debug: Log the services being sent
         log.info("📢 Services received: {}", appointmentRequestModel.getServices());
-
-
 
         // ✅ Fix: Save the first and last name correctly
         Appointment appointment = new Appointment();
@@ -307,17 +307,29 @@ public class AppointmentServiceImpl implements AppointmentService {
         parameters.put("services", savedAppointment.getServices());
         parameters.put("comments", savedAppointment.getComments());
 
-        emailService.sendEmail(customerAccount.getEmail(),"Appointment Scheduled - ACMS","appointment.html",parameters);
+        emailService.sendEmail(customerAccount.getEmail(), "Appointment Scheduled - ACMS", "appointment.html",
+                parameters);
 
         return appointmentResponseMapper.entityToResponseModel(savedAppointment);
     }
 
     @Override
-    public Page<AppointmentResponseModel> getAllAppointmentsPagination (Pageable pageable) {
+    public Page<AppointmentResponseModel> getAllAppointmentsPagination(Pageable pageable) {
         Page<Appointment> appointmentPage = appointmentRepository.findAll(pageable);
         return appointmentPage.map(appointmentResponseMapper::entityToResponseModel);
 
     }
 
-
+    @Override
+    public List<AppointmentResponseModel> getAppointmentsByCustomerEmail(String email) {
+        // Find the customer by email first
+        CustomerResponseModel customer = customerService.getCustomerByEmail(email);
+        if (customer == null) {
+            throw new NotFoundException("Customer not found for email: " + email);
+        }
+    
+        // Fetch appointments using the retrieved customerId
+        List<Appointment> appointments = appointmentRepository.findAllByCustomerId(customer.getCustomerId());
+        return appointmentResponseMapper.entityToResponseModelList(appointments);
+    }
 }

--- a/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/datalayer/AppointmentRepository.java
+++ b/src/main/java/com/ccleaninc/cclean/appointmentssubdomain/datalayer/AppointmentRepository.java
@@ -10,7 +10,13 @@ import java.util.List;
 
 public interface AppointmentRepository extends JpaRepository<Appointment, Integer> {
     Appointment findAppointmentByAppointmentIdentifier_AppointmentId(String appointmentId);
+
     Page<Appointment> findAll(Pageable pageable);
+
     @Query("SELECT a FROM Appointment a WHERE a.customerId = :customerId")
     List<Appointment> findAllByCustomerId(@Param("customerId") String customerId);
+
+    @Query("SELECT a FROM Appointment a WHERE a.customerId = (SELECT c.customerIdentifier.customerId FROM Customer c WHERE c.email = :email)")
+    List<Appointment> findAllByCustomerEmail(@Param("email") String email);    
+
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerService.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerService.java
@@ -21,5 +21,5 @@ public interface CustomerService {
 
     CustomerResponseModel getOrCreateCustomerByEmail(String email);
 
-
+    CustomerResponseModel getCustomerByEmail(String email);
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerServiceImpl.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/businesslayer/CustomerServiceImpl.java
@@ -14,13 +14,14 @@ import com.ccleaninc.cclean.customerssubdomain.datamapperlayer.CustomerResponseM
 import com.ccleaninc.cclean.customerssubdomain.presentationlayer.*;;
 
 @Service
-public class CustomerServiceImpl implements CustomerService{
+public class CustomerServiceImpl implements CustomerService {
 
     private final CustomerRepository customerRepository;
     private final CustomerResponseMapper customerResponseMapper;
     private final CustomerRequestMapper customerRequestMapper;
 
-        public CustomerServiceImpl(CustomerRepository customerRepository, CustomerResponseMapper customerResponseMapper, CustomerRequestMapper customerRequestMapper) {
+    public CustomerServiceImpl(CustomerRepository customerRepository, CustomerResponseMapper customerResponseMapper,
+            CustomerRequestMapper customerRequestMapper) {
         this.customerRepository = customerRepository;
         this.customerResponseMapper = customerResponseMapper;
         this.customerRequestMapper = customerRequestMapper;
@@ -34,16 +35,14 @@ public class CustomerServiceImpl implements CustomerService{
     @Override
     public List<CustomerResponseModel> searchCustomers(String searchTerm) {
         return customerResponseMapper.entityToResponseModelList(
-            customerRepository.searchByNameOrCompany(searchTerm)
-        );
+                customerRepository.searchByNameOrCompany(searchTerm));
     }
 
     @Override
     public CustomerResponseModel getCustomerByCustomerId(String customerId) {
         return customerResponseMapper.entityToResponseModel(
-            customerRepository.findByCustomerIdentifier_CustomerId(customerId)
-                .orElseThrow(() -> new NotFoundException("Customer not found"))
-        );
+                customerRepository.findByCustomerIdentifier_CustomerId(customerId)
+                        .orElseThrow(() -> new NotFoundException("Customer not found")));
     }
 
     @Override
@@ -54,24 +53,26 @@ public class CustomerServiceImpl implements CustomerService{
     }
 
     // @Override
-    // public CustomerResponseModel addCustomer(CustomerRequestModel customerRequestModel) {
-    //     Customer customer = customerRequestMapper.customerModelToEntity(customerRequestModel);
-    //     return customerResponseMapper.entityToResponseModel(customerRepository.save(customer));
+    // public CustomerResponseModel addCustomer(CustomerRequestModel
+    // customerRequestModel) {
+    // Customer customer =
+    // customerRequestMapper.customerModelToEntity(customerRequestModel);
+    // return
+    // customerResponseMapper.entityToResponseModel(customerRepository.save(customer));
     // }
 
     @Override
     public CustomerResponseModel addCustomer(CustomerRequestModel customerRequestModel) {
-    Customer customer = customerRequestMapper.customerModelToEntity(customerRequestModel);
+        Customer customer = customerRequestMapper.customerModelToEntity(customerRequestModel);
 
-    // Explicitly initialize the CustomerIdentifier
-    customer.setCustomerIdentifier(new CustomerIdentifier());
+        // Explicitly initialize the CustomerIdentifier
+        customer.setCustomerIdentifier(new CustomerIdentifier());
 
-    Customer savedCustomer = customerRepository.save(customer);
+        Customer savedCustomer = customerRepository.save(customer);
 
-    // Map the saved entity back to the response model
-    return customerResponseMapper.entityToResponseModel(savedCustomer);
-}
-
+        // Map the saved entity back to the response model
+        return customerResponseMapper.entityToResponseModel(savedCustomer);
+    }
 
     @Override
     public CustomerResponseModel updateCustomer(String customerId, CustomerRequestModel customerRequestModel) {
@@ -104,5 +105,21 @@ public class CustomerServiceImpl implements CustomerService{
         Customer saved = customerRepository.save(newCustomer);
         return customerResponseMapper.entityToResponseModel(saved);
     }
+
+    @Override
+    public CustomerResponseModel getCustomerByEmail(String email) {
+        Customer customer = customerRepository.findOptionalByEmail(email)
+            .orElseThrow(() -> new NotFoundException("Customer not found for email: " + email));
+    
+        return CustomerResponseModel.builder()
+            .customerId(customer.getCustomerIdentifier().getCustomerId()) // Ensure this exists
+            .firstName(customer.getFirstName())
+            .lastName(customer.getLastName())
+            .companyName(customer.getCompanyName())
+            .email(customer.getEmail())
+            .phoneNumber(customer.getPhoneNumber())
+            .address(customer.getAddress()) 
+            .build();
+    }    
 
 }

--- a/src/main/java/com/ccleaninc/cclean/customerssubdomain/datalayer/CustomerRepository.java
+++ b/src/main/java/com/ccleaninc/cclean/customerssubdomain/datalayer/CustomerRepository.java
@@ -25,5 +25,7 @@ public interface CustomerRepository extends JpaRepository<Customer, Integer>{
            "LOWER(c.lastName) LIKE LOWER(CONCAT('%', :searchTerm, '%')) OR " +
            "LOWER(c.companyName) LIKE LOWER(CONCAT('%', :searchTerm, '%'))")
     List<Customer> searchByNameOrCompany(@Param("searchTerm") String searchTerm);
+
+    Optional<Customer> findOptionalByEmail(String email);
     
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,7 +5,7 @@ INSERT INTO customers (
 -- Residential Customers
 ('c1d2e3f4-a5b6-11ec-82a8-0242ac130003', 'Vinicius', 'Velozo', NULL, 'viniciusvelozodesousa@gmail.com', '514-555-0101'),
 ('d3e4f5g6-b7c8-11ec-82a8-0242ac130003', 'Thomas', 'Bedard', NULL, 'champlaintbed@gmail.com', '514-555-0202'),
-('e4f5g6h7-c8d9-11ec-82a8-0242ac130003', 'Paul', 'Lavoie', NULL, 'paul.lavoie@mail.com', '514-555-0303'),
+('e4f5g6h7-c8d9-11ec-82a8-0242ac130003', 'Paul', 'Lavoie', NULL, 'customer@gmail.com', '514-555-0303'),
 ('f5g6h7i8-d9e0-11ec-82a8-0242ac130003', 'Sophie', 'Girard', NULL, 'sophie.girard@mail.com', '514-555-0404'),
 ('g6h7i8j9-e0f1-11ec-82a8-0242ac130003', 'Lucas', 'Fortin', NULL, 'lucas.fortin@mail.com', '514-555-0505'),
 ('h7i8j9k0-f1g2-11ec-82a8-0242ac130003', 'John', 'Doe', NULL, 'john.doe@mail.com', '514-555-0606'),

--- a/src/test/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentServiceUnitTest.java
+++ b/src/test/java/com/ccleaninc/cclean/appointmentssubdomain/businesslayer/AppointmentServiceUnitTest.java
@@ -23,18 +23,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-
-
-
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 
 @ExtendWith(MockitoExtension.class)
 public class AppointmentServiceUnitTest {
@@ -54,7 +45,6 @@ public class AppointmentServiceUnitTest {
     private Appointment appointment;
 
     private AppointmentResponseModel appointmentResponseModel;
-
 
     @BeforeEach
     void setUp() {
@@ -81,7 +71,8 @@ public class AppointmentServiceUnitTest {
     @Test
     void GetAllAppointments_shouldSucceed() {
         when(appointmentRepository.findAll()).thenReturn(List.of(appointment));
-        when(appointmentResponseMapper.entityToResponseModelList(List.of(appointment))).thenReturn(List.of(appointmentResponseModel));
+        when(appointmentResponseMapper.entityToResponseModelList(List.of(appointment)))
+                .thenReturn(List.of(appointmentResponseModel));
 
         List<AppointmentResponseModel> appointments = appointmentService.getAllAppointments();
 
@@ -103,14 +94,18 @@ public class AppointmentServiceUnitTest {
 
         assertTrue(appointments.isEmpty());
     }
+
     @Test
     void GetAppointmentByAppointmentId_shouldSucceed() {
         // Arrange
-        when(appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")).thenReturn(appointment);
+        when(appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                .thenReturn(appointment);
         when(appointmentResponseMapper.entityToResponseModel(appointment)).thenReturn(appointmentResponseModel);
 
         // Act
-        AppointmentResponseModel appointment = appointmentService.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
+        AppointmentResponseModel appointment = appointmentService
+                .getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
 
         // Assert
         assertEquals(appointmentResponseModel.getId(), appointment.getId());
@@ -124,7 +119,9 @@ public class AppointmentServiceUnitTest {
     @Test
     void GetAppointmentByAppointmentId_shouldThrowInvalidInputException() {
         // Arrange
-        when(appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")).thenReturn(null);
+        when(appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                .thenReturn(null);
 
         // Act & Assert
         try {
@@ -137,7 +134,9 @@ public class AppointmentServiceUnitTest {
     @Test
     void deleteAppointmentByAppointmentId_shouldSucceed() {
         // Arrange
-        when(appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")).thenReturn(appointment);
+        when(appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                .thenReturn(appointment);
 
         // Act
         appointmentService.deleteAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
@@ -147,7 +146,9 @@ public class AppointmentServiceUnitTest {
     @Test
     void deleteAppointmentByAppointmentId_shouldThrowNotFoundException() {
         // Arrange
-        when(appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")).thenReturn(null);
+        when(appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                .thenReturn(null);
 
         // Act & Assert
         try {
@@ -230,12 +231,15 @@ public class AppointmentServiceUnitTest {
                 .status(Status.pending)
                 .build();
 
-        when(appointmentRepository.findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")).thenReturn(appointment);
+        when(appointmentRepository
+                .findAppointmentByAppointmentIdentifier_AppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                .thenReturn(appointment);
         when(appointmentRepository.save(any(Appointment.class))).thenReturn(expectedAppointment);
         when(appointmentResponseMapper.entityToResponseModel(expectedAppointment)).thenReturn(appointmentResponseModel);
 
         // Act
-        AppointmentResponseModel response = appointmentService.updateAppointment("a1b2c3d4-e5f6-11ec-82a8-0242ac130000", appointmentRequestModel);
+        AppointmentResponseModel response = appointmentService.updateAppointment("a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                appointmentRequestModel);
 
         // Assert
         assertEquals(appointmentResponseModel.getId(), response.getId());
@@ -259,43 +263,50 @@ public class AppointmentServiceUnitTest {
         }
     }
 
-
-    /*@Test
-    void CreateAppointment_shouldSucceed() {
-        AppointmentRequestModel requestModel = AppointmentRequestModel.builder()
-                .customerId("1")
-                .appointmentDate(LocalDateTime.parse("2021-08-01T10:00"))
-                .services("services")
-                .comments("comments")
-                .status(Status.pending)
-                .build();
-
-        when(appointmentRepository.save(any(Appointment.class))).thenReturn(appointment);
-        when(appointmentResponseMapper.entityToResponseModel(any(Appointment.class))).thenReturn(appointmentResponseModel);
-
-        AppointmentResponseModel response = appointmentService.createAppointment(requestModel);
-
-        assertNotNull(response);
-        assertEquals(appointmentResponseModel.getId(), response.getId());
-        assertEquals(appointmentResponseModel.getCustomerId(), response.getCustomerId());
-    }
-
-    @Test
-    void CreateAppointment_shouldThrowInvalidInputException_whenCustomerIdIsNull() {
-        AppointmentRequestModel requestModel = AppointmentRequestModel.builder()
-                .customerId(null)
-                .appointmentDate(LocalDateTime.parse("2021-08-01T10:00"))
-                .services("services")
-                .comments("comments")
-                .status(Status.pending)
-                .build();
-
-        InvalidInputException exception = assertThrows(InvalidInputException.class, () -> {
-            appointmentService.createAppointment(requestModel);
-        });
-
-        assertEquals("Customer ID is required.", exception.getMessage());
-    } */
+    /*
+     * @Test
+     * void CreateAppointment_shouldSucceed() {
+     * AppointmentRequestModel requestModel = AppointmentRequestModel.builder()
+     * .customerId("1")
+     * .appointmentDate(LocalDateTime.parse("2021-08-01T10:00"))
+     * .services("services")
+     * .comments("comments")
+     * .status(Status.pending)
+     * .build();
+     * 
+     * when(appointmentRepository.save(any(Appointment.class))).thenReturn(
+     * appointment);
+     * when(appointmentResponseMapper.entityToResponseModel(any(Appointment.class)))
+     * .thenReturn(appointmentResponseModel);
+     * 
+     * AppointmentResponseModel response =
+     * appointmentService.createAppointment(requestModel);
+     * 
+     * assertNotNull(response);
+     * assertEquals(appointmentResponseModel.getId(), response.getId());
+     * assertEquals(appointmentResponseModel.getCustomerId(),
+     * response.getCustomerId());
+     * }
+     * 
+     * @Test
+     * void
+     * CreateAppointment_shouldThrowInvalidInputException_whenCustomerIdIsNull() {
+     * AppointmentRequestModel requestModel = AppointmentRequestModel.builder()
+     * .customerId(null)
+     * .appointmentDate(LocalDateTime.parse("2021-08-01T10:00"))
+     * .services("services")
+     * .comments("comments")
+     * .status(Status.pending)
+     * .build();
+     * 
+     * InvalidInputException exception = assertThrows(InvalidInputException.class,
+     * () -> {
+     * appointmentService.createAppointment(requestModel);
+     * });
+     * 
+     * assertEquals("Customer ID is required.", exception.getMessage());
+     * }
+     */
 
     @Test
     void CreateAppointment_shouldThrowInvalidInputException_whenAppointmentDateIsNull() {
@@ -315,9 +326,10 @@ public class AppointmentServiceUnitTest {
     }
 
     @Test
-            void getAppointmentsByCustomerId_ShouldSucceed() {
+    void getAppointmentsByCustomerId_ShouldSucceed() {
         // Setup
-        when(customerRepository.findByCustomerIdentifier_CustomerId("c1d2e3f4")).thenReturn(Optional.of(new Customer()));
+        when(customerRepository.findByCustomerIdentifier_CustomerId("c1d2e3f4"))
+                .thenReturn(Optional.of(new Customer()));
         when(appointmentRepository.findAllByCustomerId("c1d2e3f4")).thenReturn(List.of(appointment));
         when(appointmentResponseMapper.entityToResponseModelList(List.of(appointment)))
                 .thenReturn(List.of(appointmentResponseModel));
@@ -338,8 +350,7 @@ public class AppointmentServiceUnitTest {
 
         NotFoundException ex = assertThrows(
                 NotFoundException.class,
-                () -> appointmentService.getAppointmentsByCustomerId("c1d2e3f4")
-        );
+                () -> appointmentService.getAppointmentsByCustomerId("c1d2e3f4"));
         assertEquals("No customer found for ID: c1d2e3f4", ex.getMessage());
     }
 
@@ -347,8 +358,7 @@ public class AppointmentServiceUnitTest {
     void getAppointmentsByCustomerId_ShouldThrowInvalidInput_WhenCustomerIdIsBlank() {
         InvalidInputException ex = assertThrows(
                 InvalidInputException.class,
-                () -> appointmentService.getAppointmentsByCustomerId("   ")
-        );
+                () -> appointmentService.getAppointmentsByCustomerId("   "));
         assertEquals("Customer ID cannot be null or empty.", ex.getMessage());
     }
 
@@ -357,8 +367,7 @@ public class AppointmentServiceUnitTest {
         // e.g. wrong length or null
         InvalidInputException ex = assertThrows(
                 InvalidInputException.class,
-                () -> appointmentService.updateAppointmentForCustomer(null, AppointmentRequestModel.builder().build())
-        );
+                () -> appointmentService.updateAppointmentForCustomer(null, AppointmentRequestModel.builder().build()));
         assertEquals("Appointment ID must be a valid 36-character string.", ex.getMessage());
     }
 
@@ -416,7 +425,8 @@ public class AppointmentServiceUnitTest {
         Exception invalidIdException = assertThrows(InvalidInputException.class, () -> {
             appointmentService.updateAppointment(invalidAppointmentId, appointmentRequestModel);
         });
-        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId, invalidIdException.getMessage());
+        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId,
+                invalidIdException.getMessage());
     }
 
     @Test
@@ -433,7 +443,8 @@ public class AppointmentServiceUnitTest {
         Exception invalidIdException = assertThrows(InvalidInputException.class, () -> {
             appointmentService.getAppointmentByAppointmentId(invalidAppointmentId);
         });
-        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId, invalidIdException.getMessage());
+        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId,
+                invalidIdException.getMessage());
     }
 
     @Test
@@ -450,7 +461,59 @@ public class AppointmentServiceUnitTest {
         Exception invalidIdException = assertThrows(InvalidInputException.class, () -> {
             appointmentService.deleteAppointmentByAppointmentId(invalidAppointmentId);
         });
-        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId, invalidIdException.getMessage());
+        assertEquals("Appointment ID must be a valid 36-character string: " + invalidAppointmentId,
+                invalidIdException.getMessage());
+    }
+
+    @Test
+    void getAppointmentsByCustomerId_ShouldSucceed2() {
+        // Arrange
+        String customerId = "c1d2e3f4";
+        String jwtToken = "mock-jwt-token"; // Simulated JWT token
+
+        when(customerRepository.findByCustomerIdentifier_CustomerId(customerId))
+                .thenReturn(Optional.of(new Customer()));
+
+        when(appointmentRepository.findAllByCustomerId(customerId))
+                .thenReturn(List.of(appointment));
+
+        when(appointmentResponseMapper.entityToResponseModelList(List.of(appointment)))
+                .thenReturn(List.of(appointmentResponseModel));
+
+        // Act
+        List<AppointmentResponseModel> result = appointmentService.getAppointmentsByCustomerId(customerId);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(appointmentResponseModel, result.get(0));
+        verify(customerRepository).findByCustomerIdentifier_CustomerId(customerId);
+        verify(appointmentRepository).findAllByCustomerId(customerId);
+    }
+
+    @Test
+    void getAppointmentsByCustomerId_ShouldThrowNotFound_WhenCustomerNotFound2() {
+        // Arrange
+        String customerId = "c1d2e3f4";
+
+        when(customerRepository.findByCustomerIdentifier_CustomerId(customerId))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        NotFoundException ex = assertThrows(
+                NotFoundException.class,
+                () -> appointmentService.getAppointmentsByCustomerId(customerId));
+
+        assertEquals("No customer found for ID: " + customerId, ex.getMessage());
+    }
+
+    @Test
+    void getAppointmentsByCustomerId_ShouldThrowInvalidInput_WhenCustomerIdIsBlank2() {
+        // Act & Assert
+        InvalidInputException ex = assertThrows(
+                InvalidInputException.class,
+                () -> appointmentService.getAppointmentsByCustomerId("   "));
+
+        assertEquals("Customer ID cannot be null or empty.", ex.getMessage());
     }
 
 }

--- a/src/test/java/com/ccleaninc/cclean/appointmentssubdomain/presentationlayer/AppointmentControllerUnitTest.java
+++ b/src/test/java/com/ccleaninc/cclean/appointmentssubdomain/presentationlayer/AppointmentControllerUnitTest.java
@@ -24,321 +24,357 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class AppointmentControllerUnitTest {
 
-    @Mock
-    private AppointmentService appointmentService;
-
-    @InjectMocks
-    private AppointmentController appointmentController;
-
-    private AppointmentResponseModel appointmentResponseModel;
-    private AppointmentRequestModel appointmentRequestModel;
-
-    @BeforeEach
-    void setUp() {
-        LocalDateTime appointmentDate = LocalDateTime.parse("2021-08-01T10:00");
-
-        // A typical response model you expect back
-        appointmentResponseModel = AppointmentResponseModel.builder()
-                .id(1)
-                .appointmentId("123e4567-e89b-12d3-a456-426614174000")
-                .customerId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")
-                .appointmentDate(appointmentDate)
-                .services("services")
-                .comments("comments")
-                .status(Status.pending)
-                .build();
-
-        // A typical request model you send in
-        appointmentRequestModel = AppointmentRequestModel.builder()
-                .appointmentDate(appointmentDate)
-                .services("services")
-                .comments("comments")
-                .status(Status.pending)
-                .build();
-    }
-
-    @Test
-    void getAllAppointments_ShouldSucceed() {
-        when(appointmentService.getAllAppointments()).thenReturn(List.of(appointmentResponseModel));
-
-        ResponseEntity<List<AppointmentResponseModel>> response =
-                appointmentController.getAllAppointments();
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(1, response.getBody().size());
-        assertEquals(appointmentResponseModel, response.getBody().get(0));
-    }
-
-    @Test
-    void getAllAppointments_NoAppointmentsFound_ShouldReturnNotFound() {
-        when(appointmentService.getAllAppointments()).thenReturn(List.of());
-
-        ResponseEntity<List<AppointmentResponseModel>> response =
-                appointmentController.getAllAppointments();
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-    }
-
-    @Test
-    void createAppointment_ShouldSucceed() {
-        when(appointmentService.createAppointment(appointmentRequestModel))
-                .thenReturn(appointmentResponseModel);
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.createAppointment(appointmentRequestModel);
-
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(appointmentResponseModel, response.getBody());
-    }
-
-    @Test
-    void createAppointment_InvalidInput_ShouldReturnBadRequest() {
-        when(appointmentService.createAppointment(appointmentRequestModel))
-                .thenThrow(new InvalidInputException("Invalid input"));
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.createAppointment(appointmentRequestModel);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    void getAppointmentByAppointmentId_ShouldSucceed() {
-        when(appointmentService.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
-                .thenReturn(appointmentResponseModel);
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(appointmentResponseModel, response.getBody());
-    }
-
-    @Test
-    void getAppointmentByAppointmentId_AppointmentNotFound_ShouldReturnNotFound() {
-        when(appointmentService.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
-                .thenThrow(new NotFoundException("Appointment not found."));
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-    }
-
-    @Test
-    void getAppointmentByAppointmentId_InvalidInput() {
-        // Arrange
-        String invalidAppointmentId = "invalid-id";
-        when(appointmentService.getAppointmentByAppointmentId(invalidAppointmentId))
-                .thenThrow(new InvalidInputException("Invalid input"));
-
-        // Act
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.getAppointmentByAppointmentId(invalidAppointmentId);
-
-        // Assert
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void addAppointment_ShouldSucceed() {
-        when(appointmentService.addAppointment(appointmentRequestModel))
-                .thenReturn(appointmentResponseModel);
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.addAppointment(appointmentRequestModel);
-
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(appointmentResponseModel, response.getBody());
-    }
-
-    @Test
-    void addAppointment_BadRequest() {
-        // Arrange
-        when(appointmentService.addAppointment(appointmentRequestModel)).thenReturn(null);
-
-        // Act
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.addAppointment(appointmentRequestModel);
-
-        // Assert
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void addAppointment_AppointmentNotAdded_ShouldReturnBadRequest() {
-        // Service returns null if appointment not created
-        when(appointmentService.addAppointment(appointmentRequestModel)).thenReturn(null);
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.addAppointment(appointmentRequestModel);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    void updateAppointment_ShouldSucceed() {
-        when(appointmentService.updateAppointment(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        )).thenReturn(appointmentResponseModel);
-
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.updateAppointment(
-                        "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                        appointmentRequestModel
-                );
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(appointmentResponseModel, response.getBody());
-    }
-
-    @Test
-    void updateAppointment_BadRequest() {
-        // Arrange
-        String invalidAppointmentId = "invalid-id";
-        when(appointmentService.updateAppointment(invalidAppointmentId, appointmentRequestModel))
-                .thenThrow(new InvalidInputException("Invalid input"));
-
-        // Act
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.updateAppointment(invalidAppointmentId, appointmentRequestModel);
-
-        // Assert
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void updateAppointment_NotFound() {
-        // Arrange
-        String nonExistentAppointmentId = "non-existent-id";
-        when(appointmentService.updateAppointment(nonExistentAppointmentId, appointmentRequestModel))
-                .thenThrow(new NotFoundException("Appointment not found."));
-
-        // Act
-        ResponseEntity<AppointmentResponseModel> response =
-                appointmentController.updateAppointment(nonExistentAppointmentId, appointmentRequestModel);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void deleteAppointmentByAppointmentId_ShouldSucceed() {
-        // We don't need a mock "when" here, as there's no return for delete
-        ResponseEntity<Void> response =
-                appointmentController.deleteAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-
-    @Test
-    void deleteAppointmentByAppointmentId_NotFound() {
-        // Arrange
-        String nonExistentAppointmentId = "non-existent-id";
-        doThrow(new NotFoundException("Appointment not found."))
-                .when(appointmentService).deleteAppointmentByAppointmentId(nonExistentAppointmentId);
-
-        // Act
-        ResponseEntity<Void> response =
-                appointmentController.deleteAppointmentByAppointmentId(nonExistentAppointmentId);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void deleteAppointmentByAppointmentId_InvalidInput() {
-        // Arrange
-        String invalidAppointmentId = "invalid-id";
-        doThrow(new InvalidInputException("Invalid input"))
-                .when(appointmentService).deleteAppointmentByAppointmentId(invalidAppointmentId);
-
-        // Act
-        ResponseEntity<Void> response =
-                appointmentController.deleteAppointmentByAppointmentId(invalidAppointmentId);
-
-        // Assert
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void updateAppointmentCustomer_ShouldSucceed() {
-        // Suppose we have a valid AppointmentResponseModel from the service
-        when(appointmentService.updateAppointmentForCustomer(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        )).thenReturn(appointmentResponseModel);
-
-        // Act
-        ResponseEntity<AppointmentResponseModel> response = appointmentController.updateAppointmentCustomer(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        );
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertEquals(appointmentResponseModel, response.getBody());
-    }
-
-    @Test
-    void updateAppointmentCustomer_ShouldReturnBadRequest_WhenServiceReturnsNull() {
-        // If service returns null, controller returns 400
-        when(appointmentService.updateAppointmentForCustomer(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        )).thenReturn(null);
-
-        ResponseEntity<AppointmentResponseModel> response = appointmentController.updateAppointmentCustomer(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        );
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertNull(response.getBody());
-    }
-
-    @Test
-    void updateAppointmentCustomer_ShouldThrowInvalidInputException() {
-        // Arrange: Mock the service to throw InvalidInputException
-        when(appointmentService.updateAppointmentForCustomer(
-                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                appointmentRequestModel
-        )).thenThrow(new InvalidInputException("Invalid input"));
-
-        // Act & Assert: Verify the exception is thrown
-        InvalidInputException exception = assertThrows(
-                InvalidInputException.class,
-                () -> appointmentController.updateAppointmentCustomer(
-                        "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
-                        appointmentRequestModel
-                )
-        );
-
-        assertEquals("Invalid input", exception.getMessage());
-    }
-
-
-    @Test
-    void generateAppointmentsPdf_ShouldSucceed() {
-        when(appointmentService.generateAppointmentsPdf()).thenReturn(new ByteArrayOutputStream());
-
-        ResponseEntity<byte[]> response = appointmentController.generateAppointmentsPdf();
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
+        @Mock
+        private AppointmentService appointmentService;
+
+        @InjectMocks
+        private AppointmentController appointmentController;
+
+        private AppointmentResponseModel appointmentResponseModel;
+        private AppointmentRequestModel appointmentRequestModel;
+
+        @BeforeEach
+        void setUp() {
+                LocalDateTime appointmentDate = LocalDateTime.parse("2021-08-01T10:00");
+
+                // A typical response model you expect back
+                appointmentResponseModel = AppointmentResponseModel.builder()
+                                .id(1)
+                                .appointmentId("123e4567-e89b-12d3-a456-426614174000")
+                                .customerId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000")
+                                .appointmentDate(appointmentDate)
+                                .services("services")
+                                .comments("comments")
+                                .status(Status.pending)
+                                .build();
+
+                // A typical request model you send in
+                appointmentRequestModel = AppointmentRequestModel.builder()
+                                .appointmentDate(appointmentDate)
+                                .services("services")
+                                .comments("comments")
+                                .status(Status.pending)
+                                .build();
+        }
+
+        @Test
+        void getAllAppointments_ShouldSucceed() {
+                when(appointmentService.getAllAppointments()).thenReturn(List.of(appointmentResponseModel));
+
+                ResponseEntity<List<AppointmentResponseModel>> response = appointmentController.getAllAppointments();
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(1, response.getBody().size());
+                assertEquals(appointmentResponseModel, response.getBody().get(0));
+        }
+
+        @Test
+        void getAllAppointments_NoAppointmentsFound_ShouldReturnNotFound() {
+                when(appointmentService.getAllAppointments()).thenReturn(List.of());
+
+                ResponseEntity<List<AppointmentResponseModel>> response = appointmentController.getAllAppointments();
+
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        }
+
+        @Test
+        void createAppointment_ShouldSucceed() {
+                when(appointmentService.createAppointment(appointmentRequestModel))
+                                .thenReturn(appointmentResponseModel);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .createAppointment(appointmentRequestModel);
+
+                assertEquals(HttpStatus.CREATED, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(appointmentResponseModel, response.getBody());
+        }
+
+        @Test
+        void createAppointment_InvalidInput_ShouldReturnBadRequest() {
+                when(appointmentService.createAppointment(appointmentRequestModel))
+                                .thenThrow(new InvalidInputException("Invalid input"));
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .createAppointment(appointmentRequestModel);
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+
+        @Test
+        void getAppointmentByAppointmentId_ShouldSucceed() {
+                when(appointmentService.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                                .thenReturn(appointmentResponseModel);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(appointmentResponseModel, response.getBody());
+        }
+
+        @Test
+        void getAppointmentByAppointmentId_AppointmentNotFound_ShouldReturnNotFound() {
+                when(appointmentService.getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000"))
+                                .thenThrow(new NotFoundException("Appointment not found."));
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .getAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
+
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        }
+
+        @Test
+        void getAppointmentByAppointmentId_InvalidInput() {
+                // Arrange
+                String invalidAppointmentId = "invalid-id";
+                when(appointmentService.getAppointmentByAppointmentId(invalidAppointmentId))
+                                .thenThrow(new InvalidInputException("Invalid input"));
+
+                // Act
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .getAppointmentByAppointmentId(invalidAppointmentId);
+
+                // Assert
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void addAppointment_ShouldSucceed() {
+                when(appointmentService.addAppointment(appointmentRequestModel))
+                                .thenReturn(appointmentResponseModel);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .addAppointment(appointmentRequestModel);
+
+                assertEquals(HttpStatus.CREATED, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(appointmentResponseModel, response.getBody());
+        }
+
+        @Test
+        void addAppointment_BadRequest() {
+                // Arrange
+                when(appointmentService.addAppointment(appointmentRequestModel)).thenReturn(null);
+
+                // Act
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .addAppointment(appointmentRequestModel);
+
+                // Assert
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void addAppointment_AppointmentNotAdded_ShouldReturnBadRequest() {
+                // Service returns null if appointment not created
+                when(appointmentService.addAppointment(appointmentRequestModel)).thenReturn(null);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .addAppointment(appointmentRequestModel);
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+
+        @Test
+        void updateAppointment_ShouldSucceed() {
+                when(appointmentService.updateAppointment(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel)).thenReturn(appointmentResponseModel);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController.updateAppointment(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel);
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(appointmentResponseModel, response.getBody());
+        }
+
+        @Test
+        void updateAppointment_BadRequest() {
+                // Arrange
+                String invalidAppointmentId = "invalid-id";
+                when(appointmentService.updateAppointment(invalidAppointmentId, appointmentRequestModel))
+                                .thenThrow(new InvalidInputException("Invalid input"));
+
+                // Act
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .updateAppointment(invalidAppointmentId, appointmentRequestModel);
+
+                // Assert
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void updateAppointment_NotFound() {
+                // Arrange
+                String nonExistentAppointmentId = "non-existent-id";
+                when(appointmentService.updateAppointment(nonExistentAppointmentId, appointmentRequestModel))
+                                .thenThrow(new NotFoundException("Appointment not found."));
+
+                // Act
+                ResponseEntity<AppointmentResponseModel> response = appointmentController
+                                .updateAppointment(nonExistentAppointmentId, appointmentRequestModel);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void deleteAppointmentByAppointmentId_ShouldSucceed() {
+                // We don't need a mock "when" here, as there's no return for delete
+                ResponseEntity<Void> response = appointmentController
+                                .deleteAppointmentByAppointmentId("a1b2c3d4-e5f6-11ec-82a8-0242ac130000");
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+        }
+
+        @Test
+        void deleteAppointmentByAppointmentId_NotFound() {
+                // Arrange
+                String nonExistentAppointmentId = "non-existent-id";
+                doThrow(new NotFoundException("Appointment not found."))
+                                .when(appointmentService).deleteAppointmentByAppointmentId(nonExistentAppointmentId);
+
+                // Act
+                ResponseEntity<Void> response = appointmentController
+                                .deleteAppointmentByAppointmentId(nonExistentAppointmentId);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void deleteAppointmentByAppointmentId_InvalidInput() {
+                // Arrange
+                String invalidAppointmentId = "invalid-id";
+                doThrow(new InvalidInputException("Invalid input"))
+                                .when(appointmentService).deleteAppointmentByAppointmentId(invalidAppointmentId);
+
+                // Act
+                ResponseEntity<Void> response = appointmentController
+                                .deleteAppointmentByAppointmentId(invalidAppointmentId);
+
+                // Assert
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void updateAppointmentCustomer_ShouldSucceed() {
+                // Suppose we have a valid AppointmentResponseModel from the service
+                when(appointmentService.updateAppointmentForCustomer(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel)).thenReturn(appointmentResponseModel);
+
+                // Act
+                ResponseEntity<AppointmentResponseModel> response = appointmentController.updateAppointmentCustomer(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(appointmentResponseModel, response.getBody());
+        }
+
+        @Test
+        void updateAppointmentCustomer_ShouldReturnBadRequest_WhenServiceReturnsNull() {
+                // If service returns null, controller returns 400
+                when(appointmentService.updateAppointmentForCustomer(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel)).thenReturn(null);
+
+                ResponseEntity<AppointmentResponseModel> response = appointmentController.updateAppointmentCustomer(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel);
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void updateAppointmentCustomer_ShouldThrowInvalidInputException() {
+                // Arrange: Mock the service to throw InvalidInputException
+                when(appointmentService.updateAppointmentForCustomer(
+                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                appointmentRequestModel)).thenThrow(new InvalidInputException("Invalid input"));
+
+                // Act & Assert: Verify the exception is thrown
+                InvalidInputException exception = assertThrows(
+                                InvalidInputException.class,
+                                () -> appointmentController.updateAppointmentCustomer(
+                                                "a1b2c3d4-e5f6-11ec-82a8-0242ac130000",
+                                                appointmentRequestModel));
+
+                assertEquals("Invalid input", exception.getMessage());
+        }
+
+        @Test
+        void generateAppointmentsPdf_ShouldSucceed() {
+                when(appointmentService.generateAppointmentsPdf()).thenReturn(new ByteArrayOutputStream());
+
+                ResponseEntity<byte[]> response = appointmentController.generateAppointmentsPdf();
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+        }
+
+        @Test
+        void getAppointmentsByCustomerId_ShouldSucceed() {
+                // Arrange
+                String customerId = "c1d2e3f4";
+                when(appointmentService.getAppointmentsByCustomerId(customerId))
+                                .thenReturn(List.of(appointmentResponseModel));
+
+                // Act
+                ResponseEntity<List<AppointmentResponseModel>> response = appointmentController
+                                .getAppointmentsByCustomerId(customerId);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertNotNull(response.getBody());
+                assertEquals(1, response.getBody().size());
+                assertEquals(appointmentResponseModel, response.getBody().get(0));
+        }
+
+        @Test
+        void getAppointmentsByCustomerId_ShouldReturnNotFound_WhenCustomerNotFound() {
+                // Arrange
+                String customerId = "c1d2e3f4";
+                when(appointmentService.getAppointmentsByCustomerId(customerId))
+                                .thenThrow(new NotFoundException("No customer found for ID: " + customerId));
+
+                // Act
+                ResponseEntity<List<AppointmentResponseModel>> response = appointmentController
+                                .getAppointmentsByCustomerId(customerId);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                assertNull(response.getBody());
+        }
+
+        @Test
+        void getAppointmentsByCustomerId_ShouldReturnBadRequest_WhenCustomerIdIsBlank() {
+                // Arrange
+                String customerId = "   ";
+                when(appointmentService.getAppointmentsByCustomerId(customerId))
+                                .thenThrow(new InvalidInputException("Customer ID cannot be null or empty."));
+
+                // Act
+                ResponseEntity<List<AppointmentResponseModel>> response = appointmentController
+                                .getAppointmentsByCustomerId(customerId);
+
+                // Assert
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertNull(response.getBody());
+        }
 
 }


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/CCICC-97

Context:
What is the ticket about and why are we doing this change?

This ticket is about eliminating the use of IDs from the frontend. 

THIS PR ELIMINATED THE USE OF CUSTOMER ID FOR ACCESSING THE LIST OF APPOINTMENTS. 

Changes
What are the various changes and what other modules do those changes effect. This can be bullet point or sentence format.

Before and After UI (Required for UI-impacting PRs)
If this is a change to the UI, include before and after screenshots to show the differences. If this is a new UI feature, include screenshots to show reviewers what it looks like.

BEFORE: None to display.

AFTER: Video instead of screenshots.

![MyAppointmentsAFTER UI](https://github.com/user-attachments/assets/217d1c7d-2d50-4af5-acdc-da7fb0b1e625)


https://github.com/user-attachments/assets/20651051-652a-4a94-ac22-ad4542a912c0
